### PR TITLE
Fix permission of home directories

### DIFF
--- a/roles/restuser/tasks/login-defs.yml
+++ b/roles/restuser/tasks/login-defs.yml
@@ -3,3 +3,9 @@
     regexp: '^(UMASK\s+).+$'
     line: '\g<1>022'
     backrefs: yes
+
+- lineinfile:
+    dest: /etc/login.defs
+    regexp: '^(HOME_MODE\s+).+$'
+    line: '\g<1>0755'
+    backrefs: yes


### PR DESCRIPTION
Change `HOME_MODE` in `/etc/login.defs`.

Because if `HOME_MODE` is defined, `UMASK` does not affect the permission of home directories.